### PR TITLE
Add MQTT control

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A MicroPython lighting controller for the **Adafruit QT Py ESP32-S3** that drive
 ## Features
 - Motion-activated Tron burst animation with randomized timing.
 - Independent ambient lighting control (on/off, brightness, color temperature).
-- HTTP web interface at the controller IP (http://<ipaddress>) for adjusting ambient settings and animation parameters.
+- HTTP web interface at the controller IP for adjusting ambient settings and animation parameters.
 - MQTT command/state topics for automation systems.
 - Compatible with the Homebridge *easy MQTT* plug-in to expose the light to HomeKit.
 - WebREPL console (enabled by default) for remote REPL access while the device is running.
@@ -100,3 +100,10 @@ mosquitto_pub -h 10.6.13.10 -t tron/cmd/fire -m 1
 ```
 
 Once deployed, the controller runs entirely from `main.py` at boot and requires no further user interaction unless you want to adjust settings or update firmware.
+
+## Notes
+Workflow for updates
+1. Use WebREPL to update files (main.py, boot.py, etc.)
+2. Reboot
+   import machine
+    machine.reset()

--- a/README.md
+++ b/README.md
@@ -1,53 +1,99 @@
 # Tron Project
 
-A MicroPython project for the **Adafruit QT Py ESP32-S3** that creates a Tron-style chasing light effect on a WS2811 COB LED strip.  
-The effect is triggered by a PIR motion sensor and runs with randomized speed, trail length, and timing to keep it dynamic.
+A MicroPython lighting controller for the **Adafruit QT Py ESP32-S3** that drives a dual-white WS2811 COB strip. Motion on the PIR sensor can trigger a Tron-style chase animation while the base strip provides dimmable ambient lighting. The firmware exposes both a built-in web UI and MQTT topics so the lights can be automated from HomeKit/Homebridge via the *easy MQTT* plug-in.
 
 ## Features
-- Motion-activated light effect using PIR sensor.  
-- Tron-like chasing trail with configurable:
-  - Speed  
-  - Trail length  
-  - End point (fixed or variable)  
-  - Bounce mode (one-way or forward/back)  
-- Randomized delay between motion detection and effect start.  
+- Motion-activated Tron burst animation with randomized timing.
+- Independent ambient lighting control (on/off, brightness, color temperature) restored after every effect.
+- HTTP web interface at the controller IP for tweaking ambient settings and all animation parameters, plus a one-click "FIRE" button.
+- MQTT command/state topics for automation systems. Works with `umqtt.robust` when available, falls back to `umqtt.simple`, and tolerates a missing MQTT stack.
+- Compatible with the Homebridge *easy MQTT* plug-in to expose the light to HomeKit.
+- Optional WebREPL console (enabled by default) for remote REPL access while the device is running.
 
 ## Hardware
-- **Controller:** Adafruit QT Py ESP32-S3  
+- **Controller:** Adafruit QT Py ESP32-S3
 - **LED strip:** BTF Lighting FCOB addressable WS2811 IC CCT COB LED strip
-- **Motion sensor:** PIR (connected to GPIO 8 in example)  
+- **Motion sensor:** PIR (connected to GPIO 8 in the example wiring)
 
-## Pin Configuration (update in config section)
+### Pin configuration
+Update these values in `main.py` if your wiring differs:
 ```python
-LED_PIN           = GPIO18  # Data pin for LED strip
-MOTION_SENSOR_PIN = GPIO8   # PIR OUT
-LED_COUNT         = 60      # Number of LEDs, update 
+LED_PIN           = 18   # Data pin for LED strip
+MOTION_SENSOR_PIN = 8    # PIR OUT pin
+LED_COUNT         = 60   # Number of LEDs/pixels
 ```
 
-## QT Py Setup
-1. **Get the MicroPython firmware**  
-   - Download the latest MicroPython UF2 for ESP32-S3 from:  
-     [https://micropython.org/download/ESP32_GENERIC_S3/](https://micropython.org/download/ESP32_GENERIC_S3/)
+The onboard NeoPixel power enable (`NEO_PWR_EN_PIN = 38`) and data pin (`NEO_DATA_PIN = 39`) are already configured for the QT Py.
 
-2. **Install MicroPython (factory default board)**  
-   - Plug in the QT Py ESP32-S3 via USB.  
-   - The board will appear as a USB drive.  
-   - Drag and drop the `.uf2` file onto the drive.  
-   - The board will reboot into MicroPython.
+## Firmware & dependencies
+- Flash the latest MicroPython firmware for ESP32-S3 (UF2) onto the QT Py. See [Adafruit's guide](https://learn.adafruit.com/adafruit-qt-py-esp32-s3/factory-reset) for detailed steps.
+- Copy `boot.py`, `main.py`, and the `ota/` directory to the board (e.g., with Thonny, mpremote, or VS Code + MicroPico).
+- The script uses `umqtt.robust` when present, and falls back to `umqtt.simple`. Both modules ship with the official MicroPython firmware. If neither module is available on your build, the controller will continue to run without MQTT integration.
 
-3. **Reinstall or Update MicroPython (if already installed)**  
-   - Double-tap the **Reset** button to enter the TinyUF2 bootloader.  
-   - The board will mount as a USB drive again.  
-   - Drag and drop the new `.uf2` file.
+## Wi-Fi setup
+Edit `boot.py` with your network credentials:
+```python
+WIFI_SSID = "YourSSID"
+WIFI_PW   = "YourPassword"
+```
+On boot, `boot.py` will connect to the configured Wi-Fi network before `main.py` starts.
 
-4. **Recover from unknown or unresponsive state**  
-   - Follow the factory reset instructions here:  
-     [Adafruit QT Py ESP32-S3 Factory Reset](https://learn.adafruit.com/adafruit-qt-py-esp32-s3/factory-reset)  
-     - Download and reflash the TinyUF2 bootloader
-     - Use the [Adafruit WebSerial ESPTool](https://learn.adafruit.com/adafruit-qt-py-esp32-s3/factory-reset#reinstall-bootloader-3111156) in Chrome/Edge.  
-     - Once restored, repeat steps above to install MicroPython.
+## MQTT configuration
+All MQTT settings live near the top of `main.py`:
+```python
+MQTT_HOST = "10.6.13.10"
+MQTT_PORT = 1883
+MQTT_CLIENT_ID = "tron-esp32s3"
+MQTT_KEEPALIVE = 60
+```
+Adjust the broker address, port, and client ID as needed. The firmware automatically reconnects if the broker is unavailable and simply disables MQTT if no supported client library is found.
 
-5. **Upload project code**  
-   - Use an editor/IDE such as **Thonny** or **VS Code with MicroPico**.  
-   - Copy `Tron-v5.py` to the board and rename it to `main.py` so it runs on boot.
+### MQTT topics
+Command topics (subscribe in your automation platform):
+| Topic | Payload | Description |
+|-------|---------|-------------|
+| `tron/cmd/on` | `1` or `0` | Turns the ambient strip on or off. |
+| `tron/cmd/brightness` | `0`&hellip;`100` | Sets brightness percentage for the ambient strip. |
+| `tron/cmd/colortemp` | `140`&hellip;`500` | Adjusts color temperature: `500` = full warm (255,0), `140` = full cool (0,255) with a linear blend in between. |
+| `tron/cmd/fire` | `1` | Triggers a single Tron burst (ignores other values). |
 
+State topics (published with retained messages so new subscribers see the latest values):
+| Topic | Payload |
+|-------|---------|
+| `tron/state/on` | `1` if the ambient strip is on, `0` otherwise. |
+| `tron/state/brightness` | Brightness percentage `0`&hellip;`100`. |
+| `tron/state/colortemp` | Active color temperature value `140`&hellip;`500`. |
+
+### HomeKit/Homebridge integration
+Install the Homebridge *easy MQTT* plug-in and map the above command/state topics to expose the ambient strip as a HomeKit accessory. The plug-in can publish HomeKit commands to the `tron/cmd/*` topics and listen for state updates on `tron/state/*`, allowing Siri/Home app control alongside motion-triggered effects.
+
+## Web interface
+Browse to `http://<controller-ip>/` to open the built-in web UI. The page lets you:
+- Toggle the ambient lighting and set brightness (0.00&ndash;1.00) and color temperature (140&ndash;500).
+- Adjust all Tron animation parameters (speed, trail length, bounce, motion delay, etc.).
+- Fire the Tron animation manually with the **Trigger FIRE** button.
+
+Changes take effect immediately and are echoed to MQTT so HomeKit/Homebridge stays in sync.
+
+## WebREPL access
+`main.py` enables WebREPL by default (`ENABLE_WEBREPL = True`) and starts it on the MicroPython default port `8266`. Connect with the WebREPL client at `ws://<controller-ip>:8266/`. Use the `webrepl_setup` utility on the device beforehand to set a password if you have not already done so. Disable WebREPL by setting `ENABLE_WEBREPL = False` if remote REPL access is not desired.
+
+## Operation notes
+- Motion events from the PIR sensor queue Tron bursts with randomized delays and counts. Manual triggers from the web UI or MQTT run alongside motion events.
+- The ambient strip always returns to the configured steady-state (on/off, brightness, color temperature) after each animation completes.
+- A small onboard NeoPixel shows motion status (green when motion is detected).
+- The firmware tolerates MQTT outages: it retries connections every few seconds and keeps operating locally even when the broker is unreachable.
+
+## Manual triggering & testing
+You can manually trigger effects or update state from a terminal, e.g.:
+```bash
+# Turn the strip on to 60% brightness, neutral white
+mosquitto_pub -h 10.6.13.10 -t tron/cmd/on -m 1
+mosquitto_pub -h 10.6.13.10 -t tron/cmd/brightness -m 60
+mosquitto_pub -h 10.6.13.10 -t tron/cmd/colortemp -m 320
+
+# Fire a burst
+mosquitto_pub -h 10.6.13.10 -t tron/cmd/fire -m 1
+```
+
+Once deployed, the controller runs entirely from `main.py` at boot and requires no further user interaction unless you want to adjust settings or update firmware.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ A MicroPython lighting controller for the **Adafruit QT Py ESP32-S3** that drive
 
 ## Features
 - Motion-activated Tron burst animation with randomized timing.
-- Independent ambient lighting control (on/off, brightness, color temperature) restored after every effect.
-- HTTP web interface at the controller IP for tweaking ambient settings and all animation parameters, plus a one-click "FIRE" button.
-- MQTT command/state topics for automation systems. Works with `umqtt.robust` when available, falls back to `umqtt.simple`, and tolerates a missing MQTT stack.
+- Independent ambient lighting control (on/off, brightness, color temperature).
+- HTTP web interface at the controller IP (http://<ipaddress>) for adjusting ambient settings and animation parameters.
+- MQTT command/state topics for automation systems.
 - Compatible with the Homebridge *easy MQTT* plug-in to expose the light to HomeKit.
-- Optional WebREPL console (enabled by default) for remote REPL access while the device is running.
+- WebREPL console (enabled by default) for remote REPL access while the device is running.
 
 ## Hardware
 - **Controller:** Adafruit QT Py ESP32-S3
 - **LED strip:** BTF Lighting FCOB addressable WS2811 IC CCT COB LED strip
-- **Motion sensor:** PIR (connected to GPIO 8 in the example wiring)
+- **Motion sensor:** Adafruit PIR sensor
 
 ### Pin configuration
 Update these values in `main.py` if your wiring differs:
@@ -26,9 +26,12 @@ LED_COUNT         = 60   # Number of LEDs/pixels
 The onboard NeoPixel power enable (`NEO_PWR_EN_PIN = 38`) and data pin (`NEO_DATA_PIN = 39`) are already configured for the QT Py.
 
 ## Firmware & dependencies
-- Flash the latest MicroPython firmware for ESP32-S3 (UF2) onto the QT Py. See [Adafruit's guide](https://learn.adafruit.com/adafruit-qt-py-esp32-s3/factory-reset) for detailed steps.
-- Copy `boot.py`, `main.py`, and the `ota/` directory to the board (e.g., with Thonny, mpremote, or VS Code + MicroPico).
+- Flash MicroPython for ESP32-S3 to the controller.
+- Copy `boot.py` and `main.py`to the board.
 - The script uses `umqtt.robust` when present, and falls back to `umqtt.simple`. Both modules ship with the official MicroPython firmware. If neither module is available on your build, the controller will continue to run without MQTT integration.
+
+
+ Add notes/tips here on how to install MicroPython and copy files to the microcontroller. (UF2) onto the QT Py. See [Adafruit's guide](https://learn.adafruit.com/adafruit-qt-py-esp32-s3/factory-reset) for detailed steps.
 
 ## Wi-Fi setup
 Edit `boot.py` with your network credentials:
@@ -54,7 +57,7 @@ Command topics (subscribe in your automation platform):
 |-------|---------|-------------|
 | `tron/cmd/on` | `1` or `0` | Turns the ambient strip on or off. |
 | `tron/cmd/brightness` | `0`&hellip;`100` | Sets brightness percentage for the ambient strip. |
-| `tron/cmd/colortemp` | `140`&hellip;`500` | Adjusts color temperature: `500` = full warm (255,0), `140` = full cool (0,255) with a linear blend in between. |
+| `tron/cmd/colortemp` | `140`&hellip;`500` | Adjusts color temperature: `500` = full warm (255,0), `140` = full cool (0,255) with a linear blend in between. The values 500-140 appear to be the HomeKit default values for setting color temperature. |
 | `tron/cmd/fire` | `1` | Triggers a single Tron burst (ignores other values). |
 
 State topics (published with retained messages so new subscribers see the latest values):
@@ -70,8 +73,8 @@ Install the Homebridge *easy MQTT* plug-in and map the above command/state topic
 ## Web interface
 Browse to `http://<controller-ip>/` to open the built-in web UI. The page lets you:
 - Toggle the ambient lighting and set brightness (0.00&ndash;1.00) and color temperature (140&ndash;500).
-- Adjust all Tron animation parameters (speed, trail length, bounce, motion delay, etc.).
-- Fire the Tron animation manually with the **Trigger FIRE** button.
+- Adjust Tron animation parameters (speed, trail length, bounce, motion delay, etc.).
+- Fire the Tron animation manually with the **FIRE** button.
 
 Changes take effect immediately and are echoed to MQTT so HomeKit/Homebridge stays in sync.
 

--- a/main.py
+++ b/main.py
@@ -7,9 +7,24 @@ import micropython
 import uasyncio as asyncio
 
 try:
-    from umqtt.simple import MQTTClient
+    from umqtt.robust import MQTTClient as RobustMQTTClient
 except ImportError:
-    MQTTClient = None
+    RobustMQTTClient = None
+
+try:
+    from umqtt.simple import MQTTClient as SimpleMQTTClient
+except ImportError:
+    SimpleMQTTClient = None
+
+if RobustMQTTClient is not None:
+    MQTTClientClass = RobustMQTTClient
+    MQTT_CLIENT_IMPL = "umqtt.robust"
+elif SimpleMQTTClient is not None:
+    MQTTClientClass = SimpleMQTTClient
+    MQTT_CLIENT_IMPL = "umqtt.simple"
+else:
+    MQTTClientClass = None
+    MQTT_CLIENT_IMPL = None
 
 ENABLE_WEBREPL = True
 
@@ -28,9 +43,20 @@ NEO_PWR_EN_PIN = 38      # Onboard NeoPixel power enable
 # MQTT configuration
 # ----------------------------
 MQTT_HOST = "10.6.13.10"
+MQTT_PORT = 1883
 MQTT_CLIENT_ID = "tron-esp32s3"
-MQTT_TOPIC_CMD = b"tron/cmd"
-MQTT_TOPIC_STATE = b"tron/state"
+MQTT_TOPIC_CMD_ON = b"tron/cmd/on"
+MQTT_TOPIC_CMD_BRIGHTNESS = b"tron/cmd/brightness"
+MQTT_TOPIC_CMD_COLORTEMP = b"tron/cmd/colortemp"
+MQTT_TOPIC_CMD_FIRE = b"tron/cmd/fire"
+MQTT_TOPIC_STATE_ON = b"tron/state/on"
+MQTT_TOPIC_STATE_BRIGHTNESS = b"tron/state/brightness"
+MQTT_TOPIC_STATE_COLORTEMP = b"tron/state/colortemp"
+MQTT_RECONNECT_DELAY_S = 5
+MQTT_KEEPALIVE = 60
+
+COLORTEMP_MIN = 140
+COLORTEMP_MAX = 500
 
 # ----------------------------
 # Shared state
@@ -38,6 +64,7 @@ MQTT_TOPIC_STATE = b"tron/state"
 state = {
     "strip_on": False   ,
     "strip_brightness": 0.30,
+    "strip_colortemp": COLORTEMP_MAX,
     "params": {
         "BRIGHTNESS_FACTOR": 0.25,
         "WARM_LEVEL": 255,
@@ -54,6 +81,32 @@ state = {
         "BURST_GAP_S": 0.0,
     },
 }
+
+MQTT_SUB_TOPICS = (
+    MQTT_TOPIC_CMD_ON,
+    MQTT_TOPIC_CMD_BRIGHTNESS,
+    MQTT_TOPIC_CMD_COLORTEMP,
+    MQTT_TOPIC_CMD_FIRE,
+)
+
+_mqtt_client = None
+_mqtt_last_state = {
+    "on": None,
+    "brightness": None,
+    "colortemp": None,
+}
+
+_mqtt_last_activity = 0
+
+
+def _touch_mqtt_activity():
+    global _mqtt_last_activity
+    _mqtt_last_activity = utime.ticks_ms()
+
+
+def _reset_mqtt_state_cache():
+    for key in _mqtt_last_state:
+        _mqtt_last_state[key] = None
 
 # ----------------------------
 # Initialize hardware (order matters)
@@ -91,6 +144,41 @@ def request_fire(source: str):
         print("Fire queue full; dropping %s" % source)
 
 
+def clamp(value, lower, upper):
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
+def colortemp_to_levels(colortemp):
+    try:
+        value = int(colortemp)
+    except (TypeError, ValueError):
+        value = COLORTEMP_MAX
+    if value < COLORTEMP_MIN:
+        value = COLORTEMP_MIN
+    elif value > COLORTEMP_MAX:
+        value = COLORTEMP_MAX
+    span = COLORTEMP_MAX - COLORTEMP_MIN
+    if span <= 0:
+        return 255, 0
+    warm_ratio = value - COLORTEMP_MIN
+    warm_level = int((warm_ratio * 255 + span // 2) // span)
+    cool_level = 255 - warm_level
+    return warm_level, cool_level
+
+
+def brightness_to_percent(brightness):
+    percent = int(brightness * 100 + 0.5)
+    if percent < 0:
+        percent = 0
+    elif percent > 100:
+        percent = 100
+    return percent
+
+
 def set_cct_color(warm_level, cool_level):
     warm = max(0, min(255, int(warm_level)))
     cool = max(0, min(255, int(cool_level)))
@@ -102,18 +190,49 @@ def apply_steady_state(force: bool = False):
     if _anim_busy and not force:
         return
 
-    params = state["params"]
     if state["strip_on"]:
-        brightness = state["strip_brightness"]
-        brightness = max(0.0, min(1.0, brightness))
-        warm_value = int(params["WARM_LEVEL"] * brightness)
-        cool_value = int(params["COOL_LEVEL"] * brightness)
+        brightness = clamp(state["strip_brightness"], 0.0, 1.0)
+        warm_level, cool_level = colortemp_to_levels(state["strip_colortemp"])
+        warm_value = warm_level * brightness
+        cool_value = cool_level * brightness
         color = set_cct_color(warm_value, cool_value)
     else:
         color = (0, 0, 0)
 
     np.fill(color)
     np.write()
+
+
+def publish_mqtt_state(force=False):
+    client = _mqtt_client
+    if client is None:
+        return
+
+    on_payload = b"1" if state["strip_on"] else b"0"
+    brightness_pct = brightness_to_percent(state["strip_brightness"])
+    colortemp_value = int(clamp(state["strip_colortemp"], COLORTEMP_MIN, COLORTEMP_MAX))
+    payloads = {
+        "on": on_payload,
+        "brightness": str(brightness_pct).encode(),
+        "colortemp": str(colortemp_value).encode(),
+    }
+    topics = {
+        "on": MQTT_TOPIC_STATE_ON,
+        "brightness": MQTT_TOPIC_STATE_BRIGHTNESS,
+        "colortemp": MQTT_TOPIC_STATE_COLORTEMP,
+    }
+
+    for key in payloads:
+        if not force and _mqtt_last_state[key] == payloads[key]:
+            continue
+        try:
+            client.publish(topics[key], payloads[key], retain=True)
+            _mqtt_last_state[key] = payloads[key]
+            _touch_mqtt_activity()
+        except Exception as exc:
+            print("MQTT publish failed:", exc)
+            _reset_mqtt_state_cache()
+            break
 
 
 def tron_burst(params):
@@ -264,46 +383,103 @@ async def motion_poller():
 
 
 def mqtt_message(topic, msg):
-    message = msg.decode().strip().upper()
-    if message == "ON":
-        state["strip_on"] = True
-        apply_steady_state()
-    elif message == "OFF":
-        state["strip_on"] = False
-        apply_steady_state()
-    elif message.startswith("DIM:"):
+    _touch_mqtt_activity()
+
+    try:
+        payload = msg.decode().strip()
+    except Exception:
+        payload = str(msg)
+
+    topic = topic or b""
+
+    if topic == MQTT_TOPIC_CMD_ON:
+        if payload in ("1", "0"):
+            desired = payload == "1"
+            print("MQTT: base on -> %s" % ("ON" if desired else "OFF"))
+            changed = state["strip_on"] != desired
+            state["strip_on"] = desired
+            if changed:
+                apply_steady_state()
+            publish_mqtt_state(force=True)
+        else:
+            print("MQTT: invalid on payload '%s'" % payload)
+    elif topic == MQTT_TOPIC_CMD_BRIGHTNESS:
         try:
-            value = float(message.split(":", 1)[1])
-            state["strip_brightness"] = max(0.0, min(1.0, value))
-            apply_steady_state()
+            pct_value = float(payload)
         except ValueError:
-            print("Invalid DIM payload:", message)
-    elif message == "FIRE":
-        request_fire("mqtt")
+            print("MQTT: invalid brightness '%s'" % payload)
+            return
+        pct_value = clamp(pct_value, 0.0, 100.0)
+        brightness = pct_value / 100.0
+        pct_display = int(pct_value + 0.5)
+        print("MQTT: brightness -> %d%%" % pct_display)
+        changed = state["strip_brightness"] != brightness
+        state["strip_brightness"] = brightness
+        if changed:
+            apply_steady_state()
+        publish_mqtt_state(force=True)
+    elif topic == MQTT_TOPIC_CMD_COLORTEMP:
+        try:
+            colortemp_value = int(float(payload))
+        except ValueError:
+            print("MQTT: invalid colortemp '%s'" % payload)
+            return
+        colortemp_value = int(clamp(colortemp_value, COLORTEMP_MIN, COLORTEMP_MAX))
+        print("MQTT: colortemp -> %d" % colortemp_value)
+        changed = state["strip_colortemp"] != colortemp_value
+        state["strip_colortemp"] = colortemp_value
+        if changed:
+            apply_steady_state()
+        publish_mqtt_state(force=True)
+    elif topic == MQTT_TOPIC_CMD_FIRE:
+        if payload == "1":
+            print("MQTT: fire command")
+            request_fire("mqtt")
+        else:
+            print("MQTT: fire ignored payload '%s'" % payload)
     else:
-        print("Unknown MQTT command:", message)
+        print("MQTT: unhandled topic %s" % topic)
 
 
 async def mqtt_loop():
-    if MQTTClient is None:
-        print("umqtt.simple not available; MQTT disabled")
+    global _mqtt_client
+
+    if MQTTClientClass is None:
+        print("MQTT client library not available; MQTT disabled")
         return
 
+    print("MQTT using %s" % MQTT_CLIENT_IMPL)
+
     client = None
+    ping_interval_ms = 0
+    if MQTT_KEEPALIVE:
+        ping_interval_ms = int(MQTT_KEEPALIVE * 1000 / 2)
+        if ping_interval_ms <= 0:
+            ping_interval_ms = int(MQTT_KEEPALIVE * 1000)
 
     while True:
         if client is None:
             try:
-                client = MQTTClient(MQTT_CLIENT_ID, MQTT_HOST)
+                client = MQTTClientClass(
+                    MQTT_CLIENT_ID,
+                    MQTT_HOST,
+                    port=MQTT_PORT,
+                    keepalive=MQTT_KEEPALIVE,
+                )
                 client.set_callback(mqtt_message)
                 client.connect()
-                client.publish(MQTT_TOPIC_STATE, b"ONLINE", retain=True)
-                client.subscribe(MQTT_TOPIC_CMD)
-                print("MQTT connected")
+                _touch_mqtt_activity()
+                for topic in MQTT_SUB_TOPICS:
+                    client.subscribe(topic)
+                _mqtt_client = client
+                publish_mqtt_state(force=True)
+                print("MQTT connected (%s)" % MQTT_CLIENT_IMPL)
             except Exception as exc:
                 print("MQTT connect failed:", exc)
                 client = None
-                await asyncio.sleep(5)
+                _mqtt_client = None
+                _reset_mqtt_state_cache()
+                await asyncio.sleep(MQTT_RECONNECT_DELAY_S)
                 continue
 
         try:
@@ -315,8 +491,28 @@ async def mqtt_loop():
             except Exception:
                 pass
             client = None
-            await asyncio.sleep(5)
+            _mqtt_client = None
+            _reset_mqtt_state_cache()
+            await asyncio.sleep(MQTT_RECONNECT_DELAY_S)
             continue
+
+        if ping_interval_ms and hasattr(client, "ping"):
+            now = utime.ticks_ms()
+            if utime.ticks_diff(now, _mqtt_last_activity) >= ping_interval_ms:
+                try:
+                    client.ping()
+                    _touch_mqtt_activity()
+                except Exception as exc:
+                    print("MQTT ping failed:", exc)
+                    try:
+                        client.disconnect()
+                    except Exception:
+                        pass
+                    client = None
+                    _mqtt_client = None
+                    _reset_mqtt_state_cache()
+                    await asyncio.sleep(MQTT_RECONNECT_DELAY_S)
+                    continue
 
         await asyncio.sleep_ms(100)
 
@@ -398,6 +594,12 @@ def render_index():
             'value="%.2f"></label><br>'
             % state["strip_brightness"]
         ),
+        (
+            '<label>Strip Color Temp '
+            '<input type="number" name="strip_colortemp" min="%d" max="%d" step="1" '
+            'value="%d"></label><br>'
+            % (COLORTEMP_MIN, COLORTEMP_MAX, state["strip_colortemp"])
+        ),
     ]
 
     inputs = []
@@ -477,6 +679,7 @@ PARAM_TYPES = {
 STATE_PARAM_TYPES = {
     "strip_on": parse_bool,
     "strip_brightness": float,
+    "strip_colortemp": int,
 }
 
 
@@ -573,10 +776,16 @@ async def handle_http_client(reader, writer):
                     brightness = max(0.0, min(1.0, state_updates["strip_brightness"]))
                     state["strip_brightness"] = brightness
                     strip_changes["strip_brightness"] = brightness
+                if "strip_colortemp" in state_updates:
+                    colortemp = int(clamp(state_updates["strip_colortemp"], COLORTEMP_MIN, COLORTEMP_MAX))
+                    state["strip_colortemp"] = colortemp
+                    strip_changes["strip_colortemp"] = colortemp
                 if strip_changes:
                     print("Updated strip settings via HTTP:", strip_changes)
             if params_changed or strip_changes:
                 apply_steady_state()
+            if strip_changes:
+                publish_mqtt_state(force=True)
             if method == "POST":
                 body = "{\"status\":\"ok\"}"
                 content_type = "application/json"


### PR DESCRIPTION
## Summary
- use umqtt.robust when available, fall back to umqtt.simple, and subscribe to the new command topics
- maintain base on/off, brightness, and color temperature values so steady lighting returns after Tron effects
- publish MQTT state updates and expose the base color temperature control through the existing HTTP UI
- add an MQTT activity tracker with keepalive pings and forced state republishes so controllers always receive up-to-date status
- document MQTT/HomeKit setup, WebREPL access, and the web UI workflow in the README for end users

## Testing
- `python3 - <<'PY'
import ast
with open('main.py', 'r') as f:
    ast.parse(f.read())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68cdd0c1ccf88320a971b44ecd20355f