### PR TITLE
Refine animation control layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -547,15 +547,6 @@ TEMPLATE_ERROR_HTML = (
 def render_index():
     params = state["params"]
 
-    def format_label(name: str) -> str:
-        # MicroPython-compatible title case implementation
-        words = name.replace("_", " ").split()
-        titled_words = []
-        for word in words:
-            if word:
-                titled_words.append(word[0].upper() + word[1:].lower())
-        return " ".join(titled_words)
-
     def format_number(value):
         if isinstance(value, float):
             return "{:g}".format(value)
@@ -564,62 +555,104 @@ def render_index():
     brightness_value = state["strip_brightness"]
     brightness_percent = brightness_to_percent(brightness_value)
 
-    animation_controls = []
-    for key in (
-        "BRIGHTNESS_FACTOR",
-        "WARM_LEVEL",
-        "COOL_LEVEL",
-        "DELAY_MIN",
-        "DELAY_MAX",
-        "TRAIL_MIN",
-        "TRAIL_MAX",
-        "MIN_ENDPOINT",
-        "MAX_ENDPOINT",
-        "BOUNCE",
-        "MIN_MOTION_WAIT",
-        "MAX_MOTION_WAIT",
-        "BURST_GAP_S",
-    ):
-        value = params[key]
-        element_id = "param_" + key.lower()
-        if isinstance(value, bool):
-            checked_attr = " checked" if value else ""
-            animation_controls.append(
-                (
-                    '<div class="field checkbox-field">'
-                    "<input type=\"checkbox\" id=\"{element_id}\" name=\"{name}\"{checked}>"
-                    "<label for=\"{element_id}\">{label}</label>"
-                    "</div>"
-                ).format(
-                    element_id=element_id,
-                    name=key,
-                    label=format_label(key),
-                    checked=checked_attr,
-                )
-            )
+    def get_param_attrs(key):
+        value = params.get(key)
+        if value is None:
+            value = 0
+        caster = PARAM_TYPES.get(key)
+        if caster is int:
+            step = "1"
+            inputmode = "numeric"
+        elif caster is float:
+            step = "0.001"
+            inputmode = "decimal"
         else:
-            if isinstance(value, int):
-                step = "1"
-                inputmode = "numeric"
-            else:
-                step = "0.001"
-                inputmode = "decimal"
-            animation_controls.append(
-                (
-                    '<div class="field">'
-                    "<label for=\"{element_id}\">{label}</label>"
-                    "<input type=\"number\" id=\"{element_id}\" name=\"{name}\" value=\"{value}\" "
-                    "step=\"{step}\" inputmode=\"{inputmode}\">"
-                    "</div>"
-                ).format(
-                    element_id=element_id,
-                    name=key,
-                    label=format_label(key),
-                    value=format_number(value),
-                    step=step,
-                    inputmode=inputmode,
-                )
-            )
+            step = "0.001"
+            inputmode = "decimal"
+        return format_number(value), step, inputmode
+
+    brightness_factor = params.get("BRIGHTNESS_FACTOR", 0.25)
+    try:
+        brightness_factor = float(brightness_factor)
+    except (TypeError, ValueError):
+        brightness_factor = 0.25
+    brightness_factor = clamp(brightness_factor, 0.0, 1.0)
+    brightness_factor_output = "{}%".format(brightness_to_percent(brightness_factor))
+
+    warm_level = params.get("WARM_LEVEL", 255)
+    try:
+        warm_level = int(warm_level)
+    except (TypeError, ValueError):
+        warm_level = 255
+    if warm_level < 0:
+        warm_level = 0
+
+    cool_level = params.get("COOL_LEVEL", 0)
+    try:
+        cool_level = int(cool_level)
+    except (TypeError, ValueError):
+        cool_level = 0
+    if cool_level < 0:
+        cool_level = 0
+
+    temperature_sum = warm_level + cool_level
+    if temperature_sum > 0:
+        temperature_percent = int(
+            (warm_level * 100 + temperature_sum // 2) // temperature_sum
+        )
+        temperature_total_attr = temperature_sum
+    else:
+        temperature_percent = 0
+        temperature_total_attr = 255
+    if temperature_percent < 0:
+        temperature_percent = 0
+    elif temperature_percent > 100:
+        temperature_percent = 100
+    temperature_output = "{}% warm".format(temperature_percent)
+
+    def store_attrs(target, key, prefix):
+        value, step, inputmode = get_param_attrs(key)
+        target[prefix + "_value"] = value
+        target[prefix + "_step"] = step
+        target[prefix + "_inputmode"] = inputmode
+
+    format_kwargs = {
+        "hidden_fields": '<input type="hidden" name="strip_on" value="off">',
+        "strip_on_checked": " checked" if state["strip_on"] else "",
+        "power_state": "On" if state["strip_on"] else "Off",
+        "brightness_value": brightness_value,
+        "brightness_percent": brightness_percent,
+        "colortemp_value": state["strip_colortemp"],
+        "colortemp_min": COLORTEMP_MIN,
+        "colortemp_max": COLORTEMP_MAX,
+        "param_brightness_factor_value": "{:.3f}".format(brightness_factor),
+        "param_brightness_factor_output": brightness_factor_output,
+        "param_temperature_value": str(temperature_percent),
+        "param_temperature_output": temperature_output,
+        "param_temperature_total": str(temperature_total_attr),
+        "param_warm_level_value": format_number(warm_level),
+        "param_cool_level_value": format_number(cool_level),
+        "param_bounce_checked": " checked" if params.get("BOUNCE") else "",
+    }
+
+    store_attrs(format_kwargs, "DELAY_MIN", "param_delay_min")
+    store_attrs(format_kwargs, "DELAY_MAX", "param_delay_max")
+    store_attrs(format_kwargs, "TRAIL_MIN", "param_trail_min")
+    store_attrs(format_kwargs, "TRAIL_MAX", "param_trail_max")
+    store_attrs(format_kwargs, "MIN_ENDPOINT", "param_endpoint_min")
+    store_attrs(format_kwargs, "MAX_ENDPOINT", "param_endpoint_max")
+    store_attrs(format_kwargs, "MIN_MOTION_WAIT", "param_motion_wait_min")
+    store_attrs(format_kwargs, "MAX_MOTION_WAIT", "param_motion_wait_max")
+
+    gap_value, gap_step, gap_inputmode = get_param_attrs("BURST_GAP_S")
+    format_kwargs.update(
+        {
+            "param_burst_gap_min_value": gap_value,
+            "param_burst_gap_max_value": gap_value,
+            "param_burst_gap_step": gap_step,
+            "param_burst_gap_inputmode": gap_inputmode,
+        }
+    )
 
     try:
         with open(TEMPLATE_PATH, "r") as template_file:
@@ -628,17 +661,7 @@ def render_index():
         return TEMPLATE_ERROR_HTML
 
     try:
-        return template.format(
-            hidden_fields='<input type="hidden" name="strip_on" value="off">',
-            strip_on_checked=" checked" if state["strip_on"] else "",
-            power_state="On" if state["strip_on"] else "Off",
-            brightness_value=brightness_value,
-            brightness_percent=brightness_percent,
-            colortemp_value=state["strip_colortemp"],
-            colortemp_min=COLORTEMP_MIN,
-            colortemp_max=COLORTEMP_MAX,
-            animation_controls="\n".join(animation_controls),
-        )
+        return template.format(**format_kwargs)
     except (KeyError, IndexError, ValueError):
         return TEMPLATE_ERROR_HTML
 

--- a/template.html
+++ b/template.html
@@ -20,7 +20,7 @@
       main.container {{
         max-width: 720px;
         margin: 0 auto;
-        padding: 2rem 1rem 3rem;
+        padding: 2rem 1rem 7rem;
       }}
 
       article.control-panel {{
@@ -33,17 +33,18 @@
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-start;
         gap: 1rem;
       }}
 
       .panel-header h1 {{
-        margin-bottom: 0.25rem;
+        margin: 0;
       }}
 
       .panel-toggle {{
         display: inline-flex;
         align-items: center;
+        justify-content: flex-start;
         gap: 0.75rem;
         font-weight: 600;
       }}
@@ -57,13 +58,39 @@
       }}
 
       .control-section {{
-        display: grid;
-        gap: 1rem;
+        display: flex;
+        flex-direction: column;
+      }}
+
+      .control-section > * + * {{
+        margin-top: 1.5rem;
+      }}
+
+      .control-section > h2 {{
+        margin: 0;
+      }}
+
+      .control-section > h2 + * {{
+        margin-top: 0;
+      }}
+
+      .control-section + .control-section {{
+        margin-top: 2rem;
       }}
 
       .control-group {{
         display: grid;
         gap: 1rem;
+      }}
+
+      .toggle-field {{
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+      }}
+
+      .power-toggle {{
+        font-size: 1rem;
       }}
 
       .slider-field {{
@@ -86,26 +113,86 @@
         width: 100%;
       }}
 
-      .param-grid {{
+      .animation-section {{
+        display: grid;
+        gap: 1.5rem;
+      }}
+
+      .animation-sliders {{
         display: grid;
         gap: 1rem;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       }}
 
-      .param-grid .field {{
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-      }}
-
-      .param-grid .checkbox-field {{
-        flex-direction: row;
+      .switch-field {{
+        display: inline-flex;
         align-items: center;
+        justify-content: flex-start;
+        gap: 0.75rem;
+        font-weight: 600;
+      }}
+
+      .switch-field input[type="checkbox"] {{
+        transform: scale(1.1);
+      }}
+
+      .range-table {{
+        display: grid;
+        gap: 1rem;
+      }}
+
+      .range-row {{
+        display: grid;
+        gap: 0.25rem;
+      }}
+
+      .range-row .range-label {{
+        font-weight: 600;
+        font-size: 1rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }}
+
+      .range-inputs {{
+        display: grid;
         gap: 0.5rem;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }}
+
+      .range-inputs input[type="number"] {{
+        width: 100%;
+        padding: 0.3rem 0.5rem;
+        line-height: 1.2;
+        min-height: 0;
+        font-variant-numeric: tabular-nums;
+      }}
+
+      @media (max-width: 600px) {{
+        .animation-sliders {{
+          grid-template-columns: 1fr;
+        }}
+
+        .range-inputs {{
+          gap: 0.5rem;
+        }}
+      }}
+
+      .actions-bar {{
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        padding: 0.75rem 1rem;
+        background: var(--pico-background-color, #fff);
+        box-shadow: 0 -0.5rem 1.5rem rgba(0, 0, 0, 0.15);
+        z-index: 100;
       }}
 
       .actions {{
+        width: min(100%, 720px);
+        margin: 0 auto;
         display: flex;
+        justify-content: flex-end;
         flex-wrap: wrap;
         gap: 0.75rem;
         align-items: center;
@@ -123,14 +210,16 @@
           {hidden_fields}
           <header class="panel-header">
             <h1>Tron</h1>
-            <label class="panel-toggle">
-              <span>Power</span>
-              <input type="checkbox" id="strip_on" name="strip_on"{strip_on_checked} role="switch" aria-label="Tron power">
-              <span id="power-state" data-on="On" data-off="Off">{power_state}</span>
-            </label>
           </header>
           <section class="control-section">
             <div class="control-group">
+              <div class="field toggle-field">
+                <label class="panel-toggle power-toggle">
+                  <span>Power</span>
+                  <input type="checkbox" id="strip_on" name="strip_on"{strip_on_checked} role="switch" aria-label="Tron power">
+                  <span id="power-state" data-on="On" data-off="Off">{power_state}</span>
+                </label>
+              </div>
               <div class="field slider-field">
                 <label for="strip_brightness">
                   <span>Brightness</span>
@@ -153,13 +242,98 @@
           </section>
           <section class="control-section">
             <h2>Animation Parameters</h2>
-            <div class="param-grid">
-              {animation_controls}
+            <div class="animation-section">
+              <div class="animation-sliders">
+                <div class="field slider-field">
+                  <label for="param_brightness_factor">
+                    <span>Brightness</span>
+                    <output id="param_brightness_factor_output">{param_brightness_factor_output}</output>
+                  </label>
+                  <input type="range" id="param_brightness_factor" name="BRIGHTNESS_FACTOR" min="0" max="1"
+                         step="0.01" value="{param_brightness_factor_value}" data-output="param_brightness_factor_output"
+                         data-format="percent">
+                </div>
+                <div class="field slider-field">
+                  <label for="param_temperature">
+                    <span>Temperature</span>
+                    <output id="param_temperature_output">{param_temperature_output}</output>
+                  </label>
+                  <input type="range" id="param_temperature" min="0" max="100" step="1"
+                         value="{param_temperature_value}" data-output="param_temperature_output"
+                         data-format="integer" data-suffix="% warm" data-temperature-total="{param_temperature_total}"
+                         data-temperature-warm="param_warm_level" data-temperature-cool="param_cool_level">
+                </div>
+              </div>
+              <label class="switch-field" for="param_bounce">
+                <span>Bounce</span>
+                <input type="checkbox" id="param_bounce" name="BOUNCE"{param_bounce_checked} role="switch" aria-label="Bounce animation">
+              </label>
+              <div class="range-table">
+                <div class="range-row">
+                  <div class="range-label" id="range-delay-label">Delay</div>
+                  <div class="range-inputs">
+                    <input type="number" id="param_delay_min" name="DELAY_MIN" value="{param_delay_min_value}"
+                           step="{param_delay_min_step}" inputmode="{param_delay_min_inputmode}" placeholder="Min"
+                           aria-label="Delay minimum">
+                    <input type="number" id="param_delay_max" name="DELAY_MAX" value="{param_delay_max_value}"
+                           step="{param_delay_max_step}" inputmode="{param_delay_max_inputmode}" placeholder="Max"
+                           aria-label="Delay maximum">
+                  </div>
+                </div>
+                <div class="range-row">
+                  <div class="range-label" id="range-trail-label">Trail</div>
+                  <div class="range-inputs">
+                    <input type="number" id="param_trail_min" name="TRAIL_MIN" value="{param_trail_min_value}"
+                           step="{param_trail_min_step}" inputmode="{param_trail_min_inputmode}" placeholder="Min"
+                           aria-label="Trail minimum">
+                    <input type="number" id="param_trail_max" name="TRAIL_MAX" value="{param_trail_max_value}"
+                           step="{param_trail_max_step}" inputmode="{param_trail_max_inputmode}" placeholder="Max"
+                           aria-label="Trail maximum">
+                  </div>
+                </div>
+                <div class="range-row">
+                  <div class="range-label" id="range-endpoint-label">Endpoint</div>
+                  <div class="range-inputs">
+                    <input type="number" id="param_endpoint_min" name="MIN_ENDPOINT" value="{param_endpoint_min_value}"
+                           step="{param_endpoint_min_step}" inputmode="{param_endpoint_min_inputmode}" placeholder="Min"
+                           aria-label="Endpoint minimum">
+                    <input type="number" id="param_endpoint_max" name="MAX_ENDPOINT" value="{param_endpoint_max_value}"
+                           step="{param_endpoint_max_step}" inputmode="{param_endpoint_max_inputmode}" placeholder="Max"
+                           aria-label="Endpoint maximum">
+                  </div>
+                </div>
+                <div class="range-row">
+                  <div class="range-label" id="range-motion-label">Motion Wait</div>
+                  <div class="range-inputs">
+                    <input type="number" id="param_motion_wait_min" name="MIN_MOTION_WAIT" value="{param_motion_wait_min_value}"
+                           step="{param_motion_wait_min_step}" inputmode="{param_motion_wait_min_inputmode}" placeholder="Min"
+                           aria-label="Motion wait minimum">
+                    <input type="number" id="param_motion_wait_max" name="MAX_MOTION_WAIT" value="{param_motion_wait_max_value}"
+                           step="{param_motion_wait_max_step}" inputmode="{param_motion_wait_max_inputmode}" placeholder="Max"
+                           aria-label="Motion wait maximum">
+                  </div>
+                </div>
+                <div class="range-row">
+                  <div class="range-label" id="range-burst-gap-label">Burst Gap</div>
+                  <div class="range-inputs">
+                    <input type="number" id="param_burst_gap_min" name="BURST_GAP_S" value="{param_burst_gap_min_value}"
+                           step="{param_burst_gap_step}" inputmode="{param_burst_gap_inputmode}" data-sync="#param_burst_gap_max"
+                           placeholder="Min" aria-label="Burst gap minimum">
+                    <input type="number" id="param_burst_gap_max" name="BURST_GAP_S" value="{param_burst_gap_max_value}"
+                           step="{param_burst_gap_step}" inputmode="{param_burst_gap_inputmode}" data-sync="#param_burst_gap_min"
+                           placeholder="Max" aria-label="Burst gap maximum">
+                  </div>
+                </div>
+              </div>
+              <input type="hidden" id="param_warm_level" name="WARM_LEVEL" value="{param_warm_level_value}">
+              <input type="hidden" id="param_cool_level" name="COOL_LEVEL" value="{param_cool_level_value}">
             </div>
           </section>
-          <footer class="actions">
-            <button type="submit">Save &amp; Apply</button>
-            <button type="button" class="secondary" onclick="triggerFire()">Trigger Fire</button>
+          <footer class="actions-bar">
+            <div class="actions">
+              <button type="submit">Save &amp; Apply</button>
+              <button type="button" class="secondary" onclick="triggerFire()">Trigger Fire</button>
+            </div>
           </footer>
         </form>
         <p id="status" role="status" aria-live="polite"></p>
@@ -234,6 +408,83 @@ function formatOutputText(input) {{
   return value + suffix;
 }}
 
+function bindSyncedInputs() {{
+  document.querySelectorAll('input[data-sync]').forEach(function(input) {{
+    var selector = input.getAttribute('data-sync');
+    if (!selector) {{
+      return;
+    }}
+    var target = document.querySelector(selector);
+    if (!target) {{
+      return;
+    }}
+    var syncValue = function(source, dest) {{
+      dest.value = source.value;
+    }};
+    input.addEventListener('input', function() {{
+      syncValue(input, target);
+    }});
+    syncValue(input, target);
+  }});
+}}
+
+function bindTemperatureControls() {{
+  document.querySelectorAll('input[data-temperature-warm]').forEach(function(slider) {{
+    var warmId = slider.getAttribute('data-temperature-warm');
+    var coolId = slider.getAttribute('data-temperature-cool');
+    var totalAttr = slider.getAttribute('data-temperature-total');
+    var warmInput = warmId ? document.getElementById(warmId) : null;
+    var coolInput = coolId ? document.getElementById(coolId) : null;
+    if (!warmInput && !coolInput) {{
+      return;
+    }}
+    var warmInitial = warmInput ? parseFloat(warmInput.value) : NaN;
+    var coolInitial = coolInput ? parseFloat(coolInput.value) : NaN;
+    var hasInitialValues = false;
+    var initialTotal = 0;
+    if (isFinite(warmInitial) && warmInitial > 0) {{
+      hasInitialValues = true;
+      initialTotal += warmInitial;
+    }}
+    if (isFinite(coolInitial) && coolInitial > 0) {{
+      hasInitialValues = true;
+      initialTotal += coolInitial;
+    }}
+    var total = parseFloat(totalAttr);
+    if (hasInitialValues) {{
+      total = initialTotal;
+    }}
+    if (!isFinite(total) || total <= 0) {{
+      total = 255;
+    }}
+    var updateTargets = function(value) {{
+      var percent = parseFloat(value);
+      if (isNaN(percent)) {{
+        return;
+      }}
+      if (percent < 0) {{
+        percent = 0;
+      }} else if (percent > 100) {{
+        percent = 100;
+      }}
+      var warmValue = Math.round((total * percent) / 100);
+      var coolValue = Math.round(total - warmValue);
+      if (warmInput) {{
+        warmInput.value = warmValue;
+      }}
+      if (coolInput) {{
+        coolInput.value = coolValue;
+      }}
+    }};
+    slider.addEventListener('input', function() {{
+      updateTargets(slider.value);
+    }});
+    if (hasInitialValues) {{
+      updateTargets(slider.value);
+    }}
+  }});
+}}
+
 function bindOutputUpdates() {{
   document.querySelectorAll('input[data-output]').forEach(function(input) {{
     var outputId = input.getAttribute('data-output');
@@ -260,6 +511,8 @@ function updatePowerState() {{
   indicator.textContent = powerInput.checked ? onText : offText;
 }}
 
+bindSyncedInputs();
+bindTemperatureControls();
 bindOutputUpdates();
 updatePowerState();
 var powerInput = document.getElementById('strip_on');


### PR DESCRIPTION
## Summary
- move animation parameter markup generation from Python into template placeholders
- redesign the animation section with sliders, bounce switch, and paired min/max number inputs to match ambient control styling, now stacking labels above half-width min/max fields and slimming the inputs for clearer spacing on small screens
- add client-side helpers to sync burst gap inputs and tie the temperature slider to warm/cool values
- reposition the power toggle beneath the Tron heading, tighten heading spacing, and pin the action buttons to the viewport bottom for easier access

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1a109a04832095f41a1ea1eeef34